### PR TITLE
Support multiple verifiable presentation in vp_token

### DIFF
--- a/Sources/Entities/AuthorisationRequest/AuthorizationResponsePayload.swift
+++ b/Sources/Entities/AuthorisationRequest/AuthorizationResponsePayload.swift
@@ -67,14 +67,6 @@ public enum AuthorizationResponsePayload: Encodable {
     case vpToken = "vp_token"
     case presentationSubmission = "presentation_submission"
   }
-
-  var vpTokenValue: String? {
-    switch self {
-    case .openId4VPAuthorizationResponse(let vpToken, _, _, _, _):
-      vpToken.value
-    default: nil
-    }
-  }
   
   var vpTokenApu: String? {
     switch self {
@@ -113,7 +105,7 @@ public enum AuthorizationResponsePayload: Encodable {
       _
      ):
        try container.encode(presentationSubmission, forKey: .presentationSubmission)
-       try container.encode(vpToken.value, forKey: .vpToken)
+       try container.encode(vpToken, forKey: .vpToken)
        try container.encode(state, forKey: .state)
      case .noConsensusResponseData(let state, let message):
        try container.encode(state, forKey: .state)

--- a/Sources/Entities/Types/VpToken.swift
+++ b/Sources/Entities/Types/VpToken.swift
@@ -14,18 +14,29 @@
  * limitations under the License.
  */
 import Foundation
+import SwiftyJSON
 
 public typealias Base64URL = String
 
-public enum VpToken {
-  case generic(String)
-  case msoMdoc(String, apu: Base64URL) // Assuming apu is a string
+public enum VpToken: Encodable {
   
-  public var value: String {
-    switch self {
-    case .generic(let value), 
-         .msoMdoc(let value, _):
-      return value
+  case generic(String)
+  case msoMdoc(String, apu: Base64URL)
+  case json(JSON)
+  case array([MixedType])
+  
+  public enum MixedType: Encodable {
+    case string(String)
+    case json(JSON)
+    
+    public func encode(to encoder: Encoder) throws {
+      var container = encoder.singleValueContainer()
+      switch self {
+      case .string(let value):
+        try container.encode(value)
+      case .json(let value):
+        try container.encode(value)
+      }
     }
   }
   
@@ -35,6 +46,22 @@ public enum VpToken {
       return apu
     default:
       return nil
+    }
+  }
+  
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    switch self {
+    case .generic(let value),
+        .msoMdoc(let value, _):
+      try container.encode(value)
+    case .json(let value):
+      try container.encode(value)
+    case .array(let array):
+      var container = encoder.unkeyedContainer()
+      for item in array {
+        try container.encode(item)
+      }
     }
   }
 }

--- a/Tests/DirectPost/DirectPostJWTTests+Certification.swift
+++ b/Tests/DirectPost/DirectPostJWTTests+Certification.swift
@@ -89,7 +89,9 @@ final class DirectPostJWTCertificationAndConformanceTests: DiXCTest {
       
       // Obtain consent
       let consent: ClientConsent = .vpToken(
-        vpToken: .generic(TestsConstants.certCbor),
+        vpToken: .init(verifiablePresentations: [
+          .generic(TestsConstants.certCbor)
+        ]),
         presentationSubmission: .init(
           id: "psId",
           definitionID: "psId",
@@ -185,7 +187,9 @@ final class DirectPostJWTCertificationAndConformanceTests: DiXCTest {
       
       // Obtain consent
       let consent: ClientConsent = .vpToken(
-        vpToken: .generic(TestsConstants.certCbor),
+        vpToken: .init(verifiablePresentations: [
+          .generic(TestsConstants.certCbor)
+        ]),
         presentationSubmission: .init(
           id: "psId",
           definitionID: "psId",
@@ -282,7 +286,9 @@ final class DirectPostJWTCertificationAndConformanceTests: DiXCTest {
       
       // Obtain consent
       let consent: ClientConsent = .vpToken(
-        vpToken: .generic(TestsConstants.certCbor),
+        vpToken: .init(verifiablePresentations: [
+          .generic(TestsConstants.certCbor)
+        ]),
         presentationSubmission: .init(
           id: "psId",
           definitionID: "psId",

--- a/Tests/DirectPost/DirectPostJWTTests.swift
+++ b/Tests/DirectPost/DirectPostJWTTests.swift
@@ -273,7 +273,9 @@ final class DirectPostJWTTests: DiXCTest {
       
       // Obtain consent
       let consent: ClientConsent = .vpToken(
-        vpToken: .generic(TestsConstants.cbor),
+        vpToken: .init(verifiablePresentations: [
+          .generic(TestsConstants.cbor)
+        ]),
         presentationSubmission: .init(
           id: "psId",
           definitionID: "psId",
@@ -374,7 +376,9 @@ final class DirectPostJWTTests: DiXCTest {
       
       // Obtain consent
       let consent: ClientConsent = .vpToken(
-        vpToken: .generic(TestsConstants.cbor),
+        vpToken: .init(verifiablePresentations: [
+          .generic(TestsConstants.cbor)
+        ]),
         presentationSubmission: .init(
           id: "psId",
           definitionID: "psId",
@@ -462,7 +466,9 @@ final class DirectPostJWTTests: DiXCTest {
       
       // Obtain consent
       let consent: ClientConsent = .vpToken(
-        vpToken: .generic(TestsConstants.cbor),
+        vpToken: .init(verifiablePresentations: [
+          .generic(TestsConstants.cbor)
+        ]),
         presentationSubmission: .init(
           id: "psId",
           definitionID: "psId",
@@ -569,7 +575,9 @@ final class DirectPostJWTTests: DiXCTest {
 
       // Obtain consent
       let consent: ClientConsent = .vpToken(
-        vpToken: .generic(TestsConstants.cbor),
+        vpToken: .init(verifiablePresentations: [
+          .generic(TestsConstants.cbor)
+        ]),
         presentationSubmission: .init(
           id: "psId",
           definitionID: "psId",
@@ -670,7 +678,9 @@ final class DirectPostJWTTests: DiXCTest {
       
       // Obtain consent
       let consent: ClientConsent = .vpToken(
-        vpToken: .generic(TestsConstants.cbor),
+        vpToken: .init(verifiablePresentations: [
+          .generic(TestsConstants.cbor)
+        ]),
         presentationSubmission: .init(
           id: "psId",
           definitionID: "psId",
@@ -781,7 +791,9 @@ final class DirectPostJWTTests: DiXCTest {
       ))
     
     let consent: ClientConsent = .vpToken(
-      vpToken: .generic(TestsConstants.cbor),
+      vpToken: .init(verifiablePresentations: [
+        .generic(TestsConstants.cbor)
+      ]),
       presentationSubmission: .init(
         id: "psId",
         definitionID: "psId",

--- a/Tests/DirectPost/DirectPostTests.swift
+++ b/Tests/DirectPost/DirectPostTests.swift
@@ -330,7 +330,9 @@ final class DirectPostTests: DiXCTest {
       
       // Obtain consent
       let consent: ClientConsent = .vpToken(
-        vpToken: .generic(TestsConstants.cbor),
+        vpToken: .init(verifiablePresentations: [
+          .generic(TestsConstants.cbor)
+        ]),
         presentationSubmission: .init(
           id: "psId",
           definitionID: "psId",


### PR DESCRIPTION
# Description of change

This PR introduces support for multiple verifiable presentations in a vp_token.
This is a breaking change.

VpToken used to be an enum now it's a struct:

```
public struct VpToken: Encodable {
  
  public let apu: Base64URL?
  public let verifiablePresentations: [VerifiablePresentation]
  
  public enum VerifiablePresentation {
    case generic(String)
    case msoMdoc(String)
    case json(JSON)
  }
```

VpToken is now encodable and several new cases have been added according to #58 

Example usage:

```
vpToken: .init(verifiablePresentations: [
          .generic("12345)
        ])
```
## Type of change


- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes