### PR TITLE
Fix: Make optional JWK fields optional in WebKey model

### DIFF
--- a/Sources/Entities/WebKey/WebKeySet.swift
+++ b/Sources/Entities/WebKey/WebKeySet.swift
@@ -17,7 +17,7 @@ import Foundation
 import JOSESwift
 import SwiftyJSON
 
-public struct WebKeySet: Codable, Equatable {
+public struct WebKeySet: Codable, Equatable, Sendable {
   public let keys: [Key]
 
   public init(keys: [Key]) {
@@ -26,7 +26,7 @@ public struct WebKeySet: Codable, Equatable {
 
   public init(_ json: JSON) throws {
     guard let keys = json["keys"].array else {
-      throw ValidatedAuthorizationError.invalidJWTWebKeySet
+      throw ValidationError.invalidJWTWebKeySet
     }
     self.keys = try WebKeySet.transformToKey(keys)
   }
@@ -36,27 +36,27 @@ public struct WebKeySet: Codable, Equatable {
       let keySet = try? JSON(json.convertToDictionary() ?? [:]),
       let keys = keySet["keys"].array
     else {
-      throw ValidatedAuthorizationError.invalidJWTWebKeySet
+      throw ValidationError.invalidJWTWebKeySet
     }
     self.keys = try WebKeySet.transformToKey(keys)
   }
 }
 
 public extension WebKeySet {
-  struct Key: Codable, Equatable, Hashable {
+  struct Key: Codable, Equatable, Hashable, Sendable {
 
     public let kty: String
     public let use: String?
     public let kid: String?
     public let iat: Int64?
-    
+
     public let crv: String?
     public let x: String?
     public let y: String?
-    
+
     public let exponent: String?
     public let modulus: String?
-    
+
     public let alg: String?
 
     /// Coding keys for encoding and decoding the structure.
@@ -65,14 +65,14 @@ public extension WebKeySet {
       case use
       case kid
       case iat
-      
+
       case crv
       case x
       case y
-      
+
       case exponent = "e"
       case modulus = "n"
-      
+
       case alg
     }
 
@@ -122,43 +122,43 @@ fileprivate extension WebKeySet {
       WebKeySet.Key(
         kty: try key.getValue(
           for: "kty",
-          error: ValidatedAuthorizationError.validationError("key set key \"kty\" not found")
+          error: ValidationError.validationError("key set key \"kty\" not found")
         ),
         use: try? key.getValue(
           for: "use",
-          error: ValidatedAuthorizationError.validationError("key set key  \"use\" not found")
+          error: ValidationError.validationError("key set key  \"use\" not found")
         ),
         kid: try? key.getValue(
           for: "kid",
-          error: ValidatedAuthorizationError.validationError("key set key  \"kid\" not found")
+          error: ValidationError.validationError("key set key  \"kid\" not found")
         ),
         iat: try? key.getValue(
           for: "iat",
-          error: ValidatedAuthorizationError.validationError("key set key  \"iat\" not found")
+          error: ValidationError.validationError("key set key  \"iat\" not found")
         ),
         crv: try? key.getValue(
           for: "crv",
-          error: ValidatedAuthorizationError.validationError("key set key  \"crv\" not found")
+          error: ValidationError.validationError("key set key  \"crv\" not found")
         ),
         x: try? key.getValue(
           for: "x",
-          error: ValidatedAuthorizationError.validationError("key set key  \"x\" not found")
+          error: ValidationError.validationError("key set key  \"x\" not found")
         ),
         y: try? key.getValue(
           for: "y",
-          error: ValidatedAuthorizationError.validationError("key set key  \"y\" not found")
+          error: ValidationError.validationError("key set key  \"y\" not found")
         ),
         exponent: try? key.getValue(
           for: "e",
-          error: ValidatedAuthorizationError.validationError("key set key  \"x\" not found")
+          error: ValidationError.validationError("key set key  \"x\" not found")
         ),
         modulus: try? key.getValue(
           for: "n",
-          error: ValidatedAuthorizationError.validationError("key set key  \"x\" not found")
+          error: ValidationError.validationError("key set key  \"x\" not found")
         ),
         alg: try? key.getValue(
           for: "alg",
-          error: ValidatedAuthorizationError.validationError("key set key  \"y\" not found")
+          error: ValidationError.validationError("key set key  \"y\" not found")
         )
       )
     }
@@ -171,7 +171,7 @@ public extension WebKeySet {
       [JSON(jwk.toDictionary())]
     )
   }
-  
+
   init(jwks: [JWK]) throws {
     self.keys = try WebKeySet.transformToKey(jwks.map {
       try JSON($0.toDictionary())

--- a/Sources/Entities/WebKey/WebKeySet.swift
+++ b/Sources/Entities/WebKey/WebKeySet.swift
@@ -17,7 +17,7 @@ import Foundation
 import JOSESwift
 import SwiftyJSON
 
-public struct WebKeySet: Codable, Equatable, Sendable {
+public struct WebKeySet: Codable, Equatable {
   public let keys: [Key]
 
   public init(keys: [Key]) {
@@ -26,7 +26,7 @@ public struct WebKeySet: Codable, Equatable, Sendable {
 
   public init(_ json: JSON) throws {
     guard let keys = json["keys"].array else {
-      throw ValidationError.invalidJWTWebKeySet
+      throw ValidatedAuthorizationError.invalidJWTWebKeySet
     }
     self.keys = try WebKeySet.transformToKey(keys)
   }
@@ -36,27 +36,27 @@ public struct WebKeySet: Codable, Equatable, Sendable {
       let keySet = try? JSON(json.convertToDictionary() ?? [:]),
       let keys = keySet["keys"].array
     else {
-      throw ValidationError.invalidJWTWebKeySet
+      throw ValidatedAuthorizationError.invalidJWTWebKeySet
     }
     self.keys = try WebKeySet.transformToKey(keys)
   }
 }
 
 public extension WebKeySet {
-  struct Key: Codable, Equatable, Hashable, Sendable {
+  struct Key: Codable, Equatable, Hashable {
 
     public let kty: String
-    public let use: String
-    public let kid: String
+    public let use: String?
+    public let kid: String?
     public let iat: Int64?
-
+    
     public let crv: String?
     public let x: String?
     public let y: String?
-
+    
     public let exponent: String?
     public let modulus: String?
-
+    
     public let alg: String?
 
     /// Coding keys for encoding and decoding the structure.
@@ -65,21 +65,21 @@ public extension WebKeySet {
       case use
       case kid
       case iat
-
+      
       case crv
       case x
       case y
-
+      
       case exponent = "e"
       case modulus = "n"
-
+      
       case alg
     }
 
     public init(
       kty: String,
-      use: String,
-      kid: String,
+      use: String?,
+      kid: String?,
       iat: Int64?,
       crv: String?,
       x: String?,
@@ -122,43 +122,43 @@ fileprivate extension WebKeySet {
       WebKeySet.Key(
         kty: try key.getValue(
           for: "kty",
-          error: ValidationError.validationError("key set key \"kty\" not found")
+          error: ValidatedAuthorizationError.validationError("key set key \"kty\" not found")
         ),
-        use: try key.getValue(
+        use: try? key.getValue(
           for: "use",
-          error: ValidationError.validationError("key set key  \"use\" not found")
+          error: ValidatedAuthorizationError.validationError("key set key  \"use\" not found")
         ),
-        kid: try key.getValue(
+        kid: try? key.getValue(
           for: "kid",
-          error: ValidationError.validationError("key set key  \"kid\" not found")
+          error: ValidatedAuthorizationError.validationError("key set key  \"kid\" not found")
         ),
-        iat: try key.getValue(
+        iat: try? key.getValue(
           for: "iat",
-          error: ValidationError.validationError("key set key  \"iat\" not found")
+          error: ValidatedAuthorizationError.validationError("key set key  \"iat\" not found")
         ),
         crv: try? key.getValue(
           for: "crv",
-          error: ValidationError.validationError("key set key  \"crv\" not found")
+          error: ValidatedAuthorizationError.validationError("key set key  \"crv\" not found")
         ),
         x: try? key.getValue(
           for: "x",
-          error: ValidationError.validationError("key set key  \"x\" not found")
+          error: ValidatedAuthorizationError.validationError("key set key  \"x\" not found")
         ),
         y: try? key.getValue(
           for: "y",
-          error: ValidationError.validationError("key set key  \"y\" not found")
+          error: ValidatedAuthorizationError.validationError("key set key  \"y\" not found")
         ),
         exponent: try? key.getValue(
           for: "e",
-          error: ValidationError.validationError("key set key  \"x\" not found")
+          error: ValidatedAuthorizationError.validationError("key set key  \"x\" not found")
         ),
         modulus: try? key.getValue(
           for: "n",
-          error: ValidationError.validationError("key set key  \"x\" not found")
+          error: ValidatedAuthorizationError.validationError("key set key  \"x\" not found")
         ),
         alg: try? key.getValue(
           for: "alg",
-          error: ValidationError.validationError("key set key  \"y\" not found")
+          error: ValidatedAuthorizationError.validationError("key set key  \"y\" not found")
         )
       )
     }
@@ -171,7 +171,7 @@ public extension WebKeySet {
       [JSON(jwk.toDictionary())]
     )
   }
-
+  
   init(jwks: [JWK]) throws {
     self.keys = try WebKeySet.transformToKey(jwks.map {
       try JSON($0.toDictionary())

--- a/Tests/Entities/EnititiesTests.swift
+++ b/Tests/Entities/EnititiesTests.swift
@@ -402,6 +402,31 @@ class WalletMetaDataTests: XCTestCase {
     XCTAssertEqual(json["response_types_supported"].arrayValue.map { $0.stringValue }, ["vp_token", "id_token"])
     XCTAssertEqual(json["response_modes_supported"].arrayValue.map { $0.stringValue }, ["direct_post", "direct_post.jwt"])
   }
+
+  func testWebKeySetInitializationFromJSONString() throws {
+    let jsonString = """
+      {
+        "keys": [
+          {
+            "kty": "EC",
+            "crv": "P-256",
+            "x": "f83OJ3D2xF4iF42R-9DKM4TZpx4xq7se5OUzJ57Jv1g",
+            "y": "x_FEzRu9iwjJHnA8sfxfCVXovE3KcdK1WlWpeRcd3WA",
+            "alg": "ES256"
+          }
+       ]
+    }
+    """
+    let webKeySet = try WebKeySet(jsonString)
+    XCTAssertEqual(webKeySet.keys.count, 1)
+
+    let key = webKeySet.keys[0)
+    XCTAssertEqual(key.kty, "EC)
+    XCTAssertEqual(key.crv, "P-256")
+    XCTAssertEqual(key.x, "f83OJ3D2xF4iF42R-9DKM4TZpx4xq7se5OUzJ57Jv1g")
+    XCTAssertEqual(key.y, "x_FEzRu9iwjJHnA8sfxfCVXovE3KcdK1WlWpeRcd3WA")
+    XCTAssertEqual(key.alg, "ES256")
+  }  
 }
 
 final class AuthorizationRequestUnprocessedDataTests: XCTestCase {


### PR DESCRIPTION
# Description of change

This change updates the WebKey model in WebKeySet.swift to correctly treat certain JWK fields as optional, in accordance with [RFC 7517, Section 4](https://datatracker.ietf.org/doc/html/rfc7517#section-4). Previously, fields such as use, alg, kid, and others were implicitly required, which could lead to decoding errors for valid JWKs missing those optional fields.

Motivation: Ensure compatibility with a wider range of valid JWKs and improve standards compliance.

No additional dependencies are required for this change.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Unit tests were written with sample JSON input

# Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have added unit tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes