### PR TITLE
Fix VerifierId parsing for decentralized_identifier client ids with DID payloads

### DIFF
--- a/Sources/Entities/Types/VerifierId.swift
+++ b/Sources/Entities/Types/VerifierId.swift
@@ -63,32 +63,31 @@ public struct VerifierId: Sendable {
         return ValidationError.validationError(message)
       }
 
-      if clientId.contains(OpenId4VPSpec.clientIdSchemeDIDWithSeparator) {
+      guard clientId.contains(OpenId4VPSpec.clientIdSchemeSeparator) else {
         return VerifierId(scheme: .preRegistered, originalClientId: clientId)
+      }
 
-      } else if !clientId.contains(OpenId4VPSpec.clientIdSchemeSeparator) {
+      let parts = clientId.split(separator: OpenId4VPSpec.clientIdSchemeSeparator, maxSplits: 1)
+      guard parts.count == 2 else {
+        throw invalid("Invalid clientId format")
+      }
+      let schemeString = String(parts[0])
+      let originalClientId = String(parts[1])
+
+      guard let scheme = ClientIdPrefix(rawValue: schemeString) else {
+        // No recognized Client Identifier Prefix: treat the whole value as a
+        // pre-registered client id. This covers DID-shaped client ids such as
+        // "did:web:example.com", whose first segment ("did") is not a prefix.
         return VerifierId(scheme: .preRegistered, originalClientId: clientId)
+      }
 
-      } else {
-        let parts = clientId.split(separator: OpenId4VPSpec.clientIdSchemeSeparator, maxSplits: 1)
-        guard parts.count == 2 else {
-          throw invalid("Invalid clientId format")
-        }
-        let schemeString = String(parts[0])
-        let originalClientId = String(parts[1])
-
-        guard let scheme = ClientIdPrefix(rawValue: schemeString) else {
-          return VerifierId(scheme: .preRegistered, originalClientId: clientId)
-        }
-
-        switch scheme {
-        case .preRegistered:
-          return VerifierId(scheme: .preRegistered, originalClientId: clientId)
-        case .redirectUri, .x509SanDns, .x509Hash, .verifierAttestation:
-          return VerifierId(scheme: scheme, originalClientId: originalClientId)
-        case .openidFederation, .decentralizedIdentifier:
-          return VerifierId(scheme: scheme, originalClientId: originalClientId)
-        }
+      switch scheme {
+      case .preRegistered:
+        return VerifierId(scheme: .preRegistered, originalClientId: clientId)
+      case .redirectUri, .x509SanDns, .x509Hash, .verifierAttestation:
+        return VerifierId(scheme: scheme, originalClientId: originalClientId)
+      case .openidFederation, .decentralizedIdentifier:
+        return VerifierId(scheme: scheme, originalClientId: originalClientId)
       }
     }
   }

--- a/Tests/VerifierId/VerifierIdTests.swift
+++ b/Tests/VerifierId/VerifierIdTests.swift
@@ -99,6 +99,38 @@ final class VerifierIdTests: XCTestCase {
     }
   }
 
+  // Test valid DID scheme where the original client id is itself a DID
+  // (contains the "did:" separator, e.g. "decentralized_identifier:did:jwk:...")
+  func testParseValidDidClientIdWithDidPayload() {
+    let originalClientId = "did:jwk:eyJjcnYiOiJQLTI1NiIsImt0eSI6IkVDIn0"
+    let clientId = "\(OpenId4VPSpec.clientIdSchemeDid):\(originalClientId)"
+    let result = VerifierId.parse(clientId: clientId)
+
+    switch result {
+    case .success(let verifierId):
+      XCTAssertEqual(verifierId.scheme, .decentralizedIdentifier)
+      XCTAssertEqual(verifierId.originalClientId, originalClientId)
+      XCTAssertEqual(verifierId.clientId, clientId)
+    case .failure:
+      XCTFail("Parsing failed for valid DID client ID with DID payload")
+    }
+  }
+
+  // Test that a DID-shaped client id without a recognized prefix
+  // (e.g. "did:web:example.com") still falls back to pre-registered
+  func testParseDidShapedClientIdFallsBackToPreRegistered() {
+    let clientId = "did:web:example.com"
+    let result = VerifierId.parse(clientId: clientId)
+
+    switch result {
+    case .success(let verifierId):
+      XCTAssertEqual(verifierId.scheme, .preRegistered)
+      XCTAssertEqual(verifierId.originalClientId, clientId)
+    case .failure:
+      XCTFail("Parsing failed for DID-shaped pre-registered client ID")
+    }
+  }
+
   // Test clientId property for different schemes
   func testClientIdProperty() {
     let verifierId = VerifierId(scheme: .redirectUri, originalClientId: "exampleClientId")


### PR DESCRIPTION
# Description of change

Fixes #192.

`VerifierId.parse` classified any client id containing the substring `did:` as
`.preRegistered` before the Client Identifier Prefix was parsed. As a result,
`decentralized_identifier:did:...` client ids could never reach the
`.decentralizedIdentifier` scheme, and a registered
`SupportedClientIdPrefix.decentralizedIdentifier(did:lookup:)` was never selected.

This change parses the prefix first and falls back to pre-registered only when the
first segment is not a recognized prefix. The behaviour introduced with the DID
preregistered support (#177) is preserved: a bare DID such as `did:web:example.com`
is still treated as a pre-registered client id.

Note: the degenerate input `"did:"` (no method-specific id) now throws
`Invalid clientId format` instead of returning `.preRegistered`; it is not a valid
client id under any scheme.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Added unit tests in `VerifierIdTests`:
  - `decentralized_identifier:` with a real DID payload parses as `decentralizedIdentifier`
  - a DID-shaped client id without a recognized prefix (e.g. `did:web:example.com`) still falls back to pre-registered
- Full test suite passes on iOS Simulator (iPhone 16, iOS 18.5), matching the CI destination
- Verified end-to-end against the OpenID Foundation conformance suite
  (`oid4vp-1final-wallet-test-plan`, `client_id_prefix=decentralized_identifier`,
  `request_method=request_uri_signed`): the wallet authenticates the verifier via the
  DID-resolved key and the happy flow passes

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have read and followed the contribution guidelines (CONTRIBUTING.md) and the Code of Conduct
