### PR TITLE
[fix] prevent doubled Client Identifier Prefix in resolved client id

### DIFF
--- a/Sources/Entities/Types/VerifierId.swift
+++ b/Sources/Entities/Types/VerifierId.swift
@@ -32,6 +32,8 @@ public struct VerifierId: Sendable {
         return OpenId4VPSpec.clientIdSchemeRedirectUri
       case .x509SanDns:
         return OpenId4VPSpec.clientIdSchemeX509SanDns
+      case .x509Hash:
+        return OpenId4VPSpec.clientIdSchemeX509Hash
       case .verifierAttestation:
         return OpenId4VPSpec.clientIdSchemeVerifierAttestation
       case .decentralizedIdentifier:

--- a/Sources/Main/Authenticators/ClientAuthenticator.swift
+++ b/Sources/Main/Authenticators/ClientAuthenticator.swift
@@ -104,7 +104,7 @@ internal actor ClientAuthenticator {
       }
       
       return .x509Hash(
-        clientId: clientId,
+        clientId: verifierId.originalClientId,
         certificate: certificate
       )
       
@@ -123,7 +123,7 @@ internal actor ClientAuthenticator {
       }
       
       return .x509SanDns(
-        clientId: clientId,
+        clientId: verifierId.originalClientId,
         certificate: certificate
       )
       
@@ -138,11 +138,11 @@ internal actor ClientAuthenticator {
       return try verifierAttestation(
         jwt: jwt,
         supportedScheme: scheme,
-        clientId: clientId
+        clientId: verifierId.originalClientId
       )
     case .redirectUri:
       return .redirectUri(
-        clientId: clientId
+        clientId: verifierId.originalClientId
       )
     }
   }
@@ -171,7 +171,7 @@ internal actor ClientAuthenticator {
       )
     case .redirectUri:
       return .redirectUri(
-        clientId: clientId
+        clientId: verifierId.originalClientId
       )
       
     default:

--- a/Tests/DirectPost/DirectPostJWTTests.swift
+++ b/Tests/DirectPost/DirectPostJWTTests.swift
@@ -839,7 +839,7 @@ final class DirectPostJWTTests: DiXCTest {
       
       let presentation: String? = TestsConstants.sdJwtPresentations(
         transactiondata: request.transactionData,
-        clientID: request.client.id.originalClientId,
+        clientID: request.client.id.clientId,
         nonce: request.nonce,
         useSha3: false
       )

--- a/Tests/Main/Authenticators/ClientAuthenticatorTests.swift
+++ b/Tests/Main/Authenticators/ClientAuthenticatorTests.swift
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2023 European Commission
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import XCTest
+import CryptoKit
+import JOSESwift
+import SwiftASN1
+import X509
+
+@testable import OpenID4VP
+
+/// Regression coverage for the "doubled Client Identifier Prefix" bug.
+///
+/// For a verifier that identifies with a prefixed client_id (e.g. `x509_san_dns:host`),
+/// `ClientAuthenticator` used to store the raw, still-prefixed client_id on the resolved
+/// `Client`. `VerifierId.clientId` then re-prepended the scheme, yielding a doubled prefix
+/// such as `x509_san_dns:x509_san_dns:host`. The fix passes `verifierId.originalClientId`
+/// (the bare host) at the construction sites, so the composed id is single-prefixed.
+final class ClientAuthenticatorTests: XCTestCase {
+
+  /// Headline regression: a `x509_san_dns:<host>` request resolves to a `Client` whose
+  /// composed id carries a single `x509_san_dns:` prefix (not a doubled one), and whose
+  /// `originalClientId` is the bare host.
+  func testResolvedX509SanDnsClientIdIsSinglePrefixed() async throws {
+
+    let host = "verifier.example.com"
+    let clientId = "\(OpenId4VPSpec.clientIdSchemeX509SanDns):\(host)"
+
+    // Build a self-signed leaf certificate whose SAN dNSNames include the host,
+    // then a compact JWS that carries that certificate in its `x5c` header and is
+    // signed by the certificate's own key.
+    let signingKey = P256.Signing.PrivateKey()
+    let certificateBase64DER = try Self.makeSelfSignedCertificateBase64DER(
+      dnsName: host,
+      key: signingKey
+    )
+    let jwt = try Self.makeSignedJWT(
+      x5c: [certificateBase64DER],
+      signingKey: signingKey
+    )
+
+    let config = Self.makeConfiguration(
+      supportedClientIdSchemes: [
+        .x509SanDns(trust: { _ in true })
+      ]
+    )
+
+    let authenticator = ClientAuthenticator(config: config)
+    let client = try await authenticator.authenticate(
+      fetchRequest: .jwtSecured(clientId: clientId, jwt: jwt)
+    )
+
+    // The resolved client must expose the bare host as its original id ...
+    XCTAssertEqual(client.id.originalClientId, host)
+    // ... and a SINGLE-prefixed composed client id (the bug produced a doubled prefix).
+    XCTAssertEqual(client.id.clientId, clientId)
+    XCTAssertEqual(client.id.clientId, "x509_san_dns:\(host)")
+    XCTAssertFalse(
+      client.id.clientId.hasPrefix("x509_san_dns:x509_san_dns:"),
+      "Resolved client id must not carry a doubled Client Identifier Prefix"
+    )
+  }
+}
+
+// MARK: - Helpers
+
+private extension ClientAuthenticatorTests {
+
+  /// Minimal `OpenId4VPConfiguration` sufficient to drive `ClientAuthenticator`.
+  static func makeConfiguration(
+    supportedClientIdSchemes: [SupportedClientIdPrefix]
+  ) -> OpenId4VPConfiguration {
+    let privateKey = try! KeyController.generateRSAPrivateKey()
+    let publicKey = try! KeyController.generateRSAPublicKey(from: privateKey)
+    let rsaJWK = try! RSAPublicKey(
+      publicKey: publicKey,
+      additionalParameters: [
+        "use": "sig",
+        "kid": UUID().uuidString,
+        "alg": "RS256"
+      ]
+    )
+    return OpenId4VPConfiguration(
+      privateKey: try! KeyController.generateECDHPrivateKey(),
+      publicWebKeySet: try! WebKeySet(jwk: rsaJWK),
+      supportedClientIdSchemes: supportedClientIdSchemes,
+      vpFormatsSupported: ClaimFormat.default(),
+      jarConfiguration: .noEncryptionOption,
+      vpConfiguration: .default(),
+      responseEncryptionConfiguration: .unsupported
+    )
+  }
+
+  /// Builds a self-signed P-256 leaf certificate with the supplied dNSName SAN and
+  /// returns its standard-base64 DER encoding (the form `parseCertificates` consumes).
+  static func makeSelfSignedCertificateBase64DER(
+    dnsName: String,
+    key: P256.Signing.PrivateKey
+  ) throws -> String {
+    let certificateKey = Certificate.PrivateKey(key)
+    let name = try DistinguishedName {
+      CommonName(dnsName)
+    }
+    let now = Date()
+    let extensions = try Certificate.Extensions {
+      Critical(
+        BasicConstraints.isCertificateAuthority(maxPathLength: nil)
+      )
+      Critical(
+        KeyUsage(digitalSignature: true, keyCertSign: true)
+      )
+      SubjectAlternativeNames([.dnsName(dnsName)])
+    }
+    let certificate = try Certificate(
+      version: .v3,
+      serialNumber: Certificate.SerialNumber(),
+      publicKey: certificateKey.publicKey,
+      notValidBefore: now.addingTimeInterval(-60 * 60),
+      notValidAfter: now.addingTimeInterval(60 * 60 * 24 * 365),
+      issuer: name,
+      subject: name,
+      signatureAlgorithm: .ecdsaWithSHA256,
+      extensions: extensions,
+      issuerPrivateKey: certificateKey
+    )
+    var serializer = DER.Serializer()
+    try serializer.serialize(certificate)
+    return Data(serializer.serializedBytes).base64EncodedString()
+  }
+
+  /// Produces a compact ES256 JWS carrying the supplied `x5c` chain in its header,
+  /// signed by `signingKey`.
+  static func makeSignedJWT(
+    x5c: [String],
+    signingKey: P256.Signing.PrivateKey
+  ) throws -> String {
+    let header = try JWSHeader(parameters: [
+      "alg": "ES256",
+      "typ": "JWT",
+      "x5c": x5c
+    ])
+    let payload = Payload(try JSONSerialization.data(withJSONObject: [
+      "iss": "issuer",
+      "nonce": "nonce"
+    ]))
+    let secKey = try Self.makeSecKey(from: signingKey)
+    guard let signer = Signer(signatureAlgorithm: .ES256, key: secKey) else {
+      throw ValidationError.validationError("Unable to build signer")
+    }
+    let jws = try JWS(header: header, payload: payload, signer: signer)
+    return jws.compactSerializedString
+  }
+
+  /// Bridges a CryptoKit P-256 private key into a `SecKey` (ANSI X9.63 layout
+  /// `0x04 || x || y || d`) so it can be used with JOSESwift's `Signer`.
+  static func makeSecKey(from key: P256.Signing.PrivateKey) throws -> SecKey {
+    let attributes: [String: Any] = [
+      kSecAttrKeyType as String: kSecAttrKeyTypeECSECPrimeRandom,
+      kSecAttrKeyClass as String: kSecAttrKeyClassPrivate,
+      kSecAttrKeySizeInBits as String: 256
+    ]
+    var error: Unmanaged<CFError>?
+    guard let secKey = SecKeyCreateWithData(
+      key.x963Representation as CFData,
+      attributes as CFDictionary,
+      &error
+    ) else {
+      throw ValidationError.validationError("Unable to build SecKey")
+    }
+    return secKey
+  }
+}

--- a/Tests/VerifierId/VerifierIdTests.swift
+++ b/Tests/VerifierId/VerifierIdTests.swift
@@ -136,4 +136,20 @@ final class VerifierIdTests: XCTestCase {
     let verifierId = VerifierId(scheme: .redirectUri, originalClientId: "exampleClientId")
     XCTAssertEqual(verifierId.clientId, "\(OpenId4VPSpec.clientIdSchemeRedirectUri):exampleClientId")
   }
+
+  // Regression: the `.x509Hash` scheme must be re-prefixed by the `clientId` composer.
+  // Before the fix the composer's prefix switch fell through to `default: return nil`
+  // for `.x509Hash`, so `clientId` returned the bare original id with no prefix.
+  func testClientIdComposesX509HashPrefix() {
+    let verifierId = VerifierId(scheme: .x509Hash, originalClientId: "ABC123")
+    XCTAssertEqual(verifierId.clientId, "\(OpenId4VPSpec.clientIdSchemeX509Hash):ABC123")
+    XCTAssertEqual(verifierId.clientId, "x509_hash:ABC123")
+  }
+
+  // Invariant: the `.x509SanDns` scheme composes a single `x509_san_dns:` prefix.
+  func testClientIdComposesX509SanDnsPrefix() {
+    let verifierId = VerifierId(scheme: .x509SanDns, originalClientId: "verifier.example.com")
+    XCTAssertEqual(verifierId.clientId, "\(OpenId4VPSpec.clientIdSchemeX509SanDns):verifier.example.com")
+    XCTAssertEqual(verifierId.clientId, "x509_san_dns:verifier.example.com")
+  }
 }


### PR DESCRIPTION
Issue: https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vp-swift/issues/195 

# Description of change

## Problem

In OpenID4VP, a Verifier identifies itself with a **Client Identifier Prefix** ([OpenID4VP 1.0 §5.9](https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#section-5.9)): the scheme is encoded as a colon-separated prefix on `client_id`, e.g. `x509_san_dns:verifier.example.com`. The wallet must echo this exact value wherever the Verifier's identity is required — the SD-JWT KeyBinding JWT `aud`, and the mdoc `OID4VPHandover` inside the `SessionTranscript`.

For Verifiers that authenticate with the **`x509_san_dns`** scheme, the resolved client id is produced with a **doubled prefix**:

```
client_id sent by verifier:   x509_san_dns:verifier.example.com
client_id resolved by lib:    x509_san_dns:x509_san_dns:verifier.example.com   ❌
```

This breaks presentation to such Verifiers:

- **SD-JWT** → rejected with `InvalidVpToken` / `ContainsInvalidKeyBindingJwt` (*"JWT aud claim has value [x509_san_dns:x509_san_dns:…], must be [x509_san_dns:…]"*).
- **mdoc** → the doubled id poisons the `OID4VPHandover`, so the `SessionTranscript` the wallet signs differs from the one the Verifier reconstructs, and the response is rejected with `InvalidDeviceSignature`.

Verifiers that authenticate with **`x509_hash`** (e.g. the EUDI reference verifier) are **not** affected — they work today. That contrast points to the root cause. Two issues are in play; they cancel for `x509_hash` but compound for `x509_san_dns`:

1. **`ClientAuthenticator` stores the raw, still-prefixed `client_id`** on the resolved `Client`, instead of the bare client id. (affects every prefixed scheme)
2. **`VerifierId.clientId` then re-prepends the scheme prefix** — but only for the schemes present in its `switch`. `x509_san_dns` *is* present (→ prefix added a second time → doubled), while `x509_hash` is *missing* (falls through to `default → nil`, so the already-prefixed stored value passes through unchanged → accidentally single).

So `x509_san_dns` hits both 1 and 2 → doubled; `x509_hash` hits only 1 → single (by accident).

## How the Kotlin port handles it (reference behavior)

The sibling library [`eudi-lib-jvm-siop-openid4vp-kt`](https://github.com/eu-digital-identity-wallet/eudi-lib-jvm-siop-openid4vp-kt) does this correctly; this PR aligns the Swift library with it.

**1 — it stores the bare `originalClientId` for every scheme.** In [`RequestAuthenticator.kt`](https://github.com/eu-digital-identity-wallet/eudi-lib-jvm-siop-openid4vp-kt/blob/v0.12.2/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestAuthenticator.kt) the client id is parsed **once** into its bare form, and every branch uses that bare value:

```kotlin
// originalClientIdAndPrefix(...) → returns the BARE id
val verifierId = VerifierId.parse(clientId).getOrElse { ... }
return verifierId.originalClientId to supportedClientIdPrefix          // bare

// authenticateClient(...) → every branch stores originalClientId (bare)
val (originalClientId, clientIdPrefix) = originalClientIdAndPrefix(requestObject)
return when (clientIdPrefix) {
    is X509SanDns          -> AuthenticatedClient.X509SanDns(originalClientId, chain)
    is X509Hash            -> AuthenticatedClient.X509Hash(originalClientId, chain)
    is VerifierAttestation -> AuthenticatedClient.VerifierAttestation(originalClientId, ...)
    RedirectUri            -> AuthenticatedClient.RedirectUri(originalClientIdAsUri)
    ...
}
```

**2 — its `clientId` composer covers every scheme.** In [`Types.kt`](https://github.com/eu-digital-identity-wallet/eudi-lib-jvm-siop-openid4vp-kt/blob/v0.12.2/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Types.kt) `VerifierId.clientId` is an exhaustive `when` that prepends a prefix for **all** schemes, including `X509Hash`:

```kotlin
val clientId: String = run {
    val prefix = when (prefix) {
        ClientIdPrefix.X509SanDns -> OpenId4VPSpec.CLIENT_ID_PREFIX_X509_SAN_DNS
        ClientIdPrefix.X509Hash   -> OpenId4VPSpec.CLIENT_ID_PREFIX_X509_HASH   // present
        ...                                                                     // one case per scheme
    }
    buildString { if (prefix != null) { append(prefix); append(SEPARATOR) }; append(originalClientId) }
}
```

Net Kotlin behavior: **bare id in, single prefix out, for every scheme** — it can never double, and `x509_hash` is correct by construction rather than by accident.

## What changed in Swift

This PR makes the Swift library behave identically.

**`Sources/Main/Authenticators/ClientAuthenticator.swift`** — at every prefixed construction site (in *both* `getClient` overloads), store the bare `verifierId.originalClientId` instead of the raw `clientId`:

```swift
// before
return .x509SanDns(clientId: clientId, certificate: certificate)
// after
return .x509SanDns(clientId: verifierId.originalClientId, certificate: certificate)
```

Applied to `.x509SanDns`, `.x509Hash`, `.verifierAttestation`, and `.redirectUri`.

**`Sources/Entities/Types/VerifierId.swift`** — add the missing `.x509Hash` case to the `clientId` prefix composer, so every scheme composes its prefix (mirroring the Kotlin `when`):

```swift
case .x509SanDns:
  return OpenId4VPSpec.clientIdSchemeX509SanDns
case .x509Hash:                                  // added
  return OpenId4VPSpec.clientIdSchemeX509Hash
case .verifierAttestation:
  ...
```

`x509_hash` needs **both** changes together: storing the bare id alone would *drop* its prefix (the composer lacked the case), and adding the composer case alone would *double* it (the stored value was still prefixed). With both, `x509_hash` yields the same single-prefixed value it does today — now by design rather than by two bugs cancelling.

Left unchanged (already correct): `preRegistered` (no prefix, never doubled) and `decentralizedIdentifier` (stores a parsed DID, doesn't double).

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added self-contained unit tests (no live verifier required):

- **`VerifierIdTests`** — `VerifierId(scheme: .x509Hash, originalClientId:).clientId` composes a single `x509_hash:` prefix (plus the `x509_san_dns` invariant).
- **`ClientAuthenticatorTests`** — generates a self-signed certificate with a `dNSName` SAN, signs a JAR carrying it in `x5c`, resolves an `x509_san_dns:<host>` request through `ClientAuthenticator`, and asserts the resolved `client.id.clientId` is single-prefixed and `originalClientId` is the bare host.
- Verified red→green: both fail on `main` (emitting the exact `x509_san_dns:x509_san_dns:…` and missing-`x509_hash`-prefix output) and pass with this change. `swift test` is green.

# Checklist

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes