### PR TITLE
Update TrustedAuthorityType.swift

### DIFF
--- a/Sources/DCQL/TrustedAuthorityType.swift
+++ b/Sources/DCQL/TrustedAuthorityType.swift
@@ -133,8 +133,8 @@ public struct TrustedAuthority: Codable, Equatable, Sendable {
   }
   
   private enum CodingKeys: String, CodingKey {
-    case type  = "trusted_authority_type"
-    case values = "trusted_authority_values"
+    case type
+    case values
   }
   
   /// Decodes a `TrustedAuthority` from its JSON representation, validating its contents.


### PR DESCRIPTION
Removed the coding keys "trusted_authority_type", "trusted_authority_values". This change will make the implementation default to "type" and "values"

Please refer to this issue: https://github.com/eu-digital-identity-wallet/eudi-lib-ios-openid4vp-swift/issues/199